### PR TITLE
Fix link to OS's updated licencing page

### DIFF
--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -8,7 +8,7 @@
   
 <h2>Licensing</h2>
   
-Great Britain postcode data may be used under the terms of the <a href="http://www.ordnancesurvey.co.uk/business-and-government/licensing/using-creating-data-with-os-products/os-opendata.html">ONSPD licence</a></p>
+Great Britain postcode data may be used under the terms of the <a href="http://www.ordnancesurvey.co.uk/business-and-government/licensing/using-creating-data-with-os-products/os-opendata.html">OS OpenData licence</a>. Northern Ireland postcode data may be used under the terms of the <a href="http://www.ons.gov.uk/ons/guide-method/geography/products/postcode-directories/-nspp-/onspd-open-licence.doc">ONSPD licence</a>
 
 <h2>Support</h2>
 


### PR DESCRIPTION
When I looked up the licensing terms on this site for using latlng data derived from postcodes, I came across a broken link on http://www.ordnancesurvey.co.uk/

I _think_ this the corrected page, but I'm not as close to the source material as you were, so please let me know this PR links to the right one.
